### PR TITLE
Add react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.vagrant
 .idea
 /tmp
+/browser-build

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "main": "src/main.js",
   "scripts": {
     "build": "electron-packager ./src Matterfront --out=dist --ignore='^/dist$' --prune --asar --platform=all --arch=all --version=$npm_package_electronVersion --app-bundle-id='org.matterfront.app' --app-version=$npm_package_version --helper-bundle-id='org.matterfront.app.helper' --overwrite --icon=resources/mattermost",
+    "js": "webpack",
     "lint": "eslint . --ignore-path .gitignore",
     "start": "electron .",
+    "start-watch": "webpack-dev-server --port 9000",
     "test": "mocha",
-    "watch": "mocha watch"
+    "test-watch": "mocha watch"
   },
   "electronVersion": "0.34.2",
   "repository": {
@@ -30,18 +32,27 @@
     "url": "https://github.com/lloeki/matterfront/issues"
   },
   "devDependencies": {
+    "babel-core": "~6.3.13",
+    "babel-loader": "~6.2.0",
+    "babel-preset-react": "~6.3.13",
     "chai": "~3.4.1",
+    "css-loader": "~0.23.0",
     "electron-prebuilt": "^0.34.2",
     "eslint": "~1.10.2",
     "ghooks": "~1.0.1",
-    "mocha": "~2.3.4"
+    "mocha": "~2.3.4",
+    "style-loader": "~0.13.0",
+    "webpack": "~1.12.9",
+    "webpack-dev-server": "~1.14.0"
   },
   "dependencies": {
     "electron-packager": "^5.1.1",
     "ini": "~1.3.4",
     "mkdirp": "~0.5.1",
     "nconf": "~0.8.2",
-    "path-extra": "~3.0.0"
+    "path-extra": "~3.0.0",
+    "react": "~0.14.3",
+    "react-dom": "~0.14.3"
   },
   "config": {
     "ghooks": {

--- a/src/browser/app.jsx
+++ b/src/browser/app.jsx
@@ -1,0 +1,15 @@
+var React = require("react");
+
+var App = React.createClass({
+  render: function(){
+    //These will be converted to React components
+    return (
+      <div>
+        <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js"></webview>
+        <div id='overlay'></div>
+      </div>
+    );
+  }
+});
+
+module.exports = App;

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -5,9 +5,8 @@
     <title>Matterfront</title>
   </head>
   <body>
+    <div id="app"></div>
     <script src="http://localhost:9000/webpack-dev-server.js"></script>
     <script src="http://localhost:9000/browser-build/index.js"></script>
-    <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js"></webview>
-    <div id='overlay'></div>
   </body>
 </html>

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -3,16 +3,10 @@
   <head>
     <meta charset="UTF-8">
     <title>Matterfront</title>
-    <link href="index.css" rel="stylesheet" type="text/css" />
-  <script>
-    // force load electron
-    process.versions['electron']
-  </script>
-  <script src='load-src.js'></script>
-  <script src='window-opener.js'></script>
-  <script src='overlay.js'></script>
   </head>
   <body>
+    <script src="http://localhost:9000/webpack-dev-server.js"></script>
+    <script src="http://localhost:9000/browser-build/index.js"></script>
     <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js"></webview>
     <div id='overlay'></div>
   </body>

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,6 +1,15 @@
-process.versions['electron'];
+var App = require("./app.jsx");
+var React = require("react");
+var ReactDOM = require("react-dom");
 require('./index.css');
 
+process.versions['electron'];
+
+var domElement = document.querySelector("#app");
+var reactElement = React.createElement(App);
+ReactDOM.render(reactElement, domElement);
+
+//All of this code will be modularized properly and moved into React components
 require('./load-src.js');
 require('./window-opener.js');
 require('./overlay.js');

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,0 +1,6 @@
+process.versions['electron'];
+require('./index.css');
+
+require('./load-src.js');
+require('./window-opener.js');
+require('./overlay.js');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,32 @@
+var webpack = require('webpack');
+module.exports = {
+  target: "electron",
+  entry: {
+    app: ['webpack/hot/dev-server', './src/browser/index.js'],
+  },
+  output: {
+    path: './browser-build',
+    filename: 'index.js',
+    publicPath: 'http://localhost:9000/browser-build/'
+  },
+  devServer: {
+    contentBase: './',
+    publicPath: 'http://localhost:9000/browser-build/'
+  },
+  module: {
+    loaders: [{
+      test: /\.jsx?$/,
+      loader: 'babel',
+      exclude: /node_modules/,
+      query: {
+        presets:['react']
+      }
+    }, {
+      test: /\.css$/,
+      loader: 'style!css'
+    }]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin()
+  ]
+}


### PR DESCRIPTION
If we want to add more complex html and JS for managing teams and app settings, we really need to structure our browser-side code a bit more. This is just a tiny step towards turning the Matterfront wrapper UI into a React app. Because React and JSX require an ES6 compiler, we'll have to use WebPack with Babel for our front-end build instead of relying solely on Electron.

You can hopefully see what I did by following the commits, but here's a summary:

- Set up the webpack and react dependencies
- Add a webpack.config.js file, which includes hot-reload functionality for faster development
- Split the scripts out of the index.html and into an index.js file that serves as our entry point for webpack
- Create a root `App` component that will serve as the base for our app

Next steps are to start turning other code like the overlay and team webview into React components. Then we can add more react components to actually show a team list, and render multiple team webviews, etc.