### PR TITLE
Multi team notifications

### DIFF
--- a/electron-watch.js
+++ b/electron-watch.js
@@ -5,15 +5,21 @@ var webpack = require("webpack");
 var webpackConfig = require("./webpack.config.js");
 
 webpackConfig.entry.push("./src/browser/dev-mode.js");
+webpackConfig.devtool = "source-map";
 
 var compiler = webpack(webpackConfig);
 var webpackWatcher = compiler.watch({}, function(err, stats){
   if (err){
     console.error("webpack error:", err);
-  } else {
+  } else if (stats.compilation.errors && stats.compilation.errors.length){
+     console.error("webpack errors:")
+     stats.compilation.errors.forEach(function(error){
+       console.error(error.message);
+     });
+  }else {
     startAppOnFirstRun();
     var elapsed = stats.endTime - stats.startTime;
-    console.info("webpack success:", elapsed + "ms");
+    console.info("\n\nwebpack success:", elapsed + "ms");
   }
 });
 

--- a/src/browser/app-state.js
+++ b/src/browser/app-state.js
@@ -16,6 +16,8 @@ var onSetConnectionState = function(currentState, connectionState){
 };
 
 var onAddTeam = function(currentState, team){
+  team.unreadCount = 0;
+  team.mentionCount = 0;
   currentState.teams[team.name] = team;
   var isFirstTeam = (Object.keys(currentState.teams).length === 1);
   var noneSelected = (currentState.selectedTeam === "");
@@ -28,7 +30,17 @@ var onAddTeam = function(currentState, team){
 var onSelectTeam = function(currentState, teamName){
   currentState.selectedTeam = teamName;
   return currentState;
-}
+};
+
+var onSetUnreadCount = function(currentState, event){
+  currentState.teams[event.teamName].unreadCount = event.unreadCount;
+  return currentState;
+};
+
+var onSetMentionCount = function(currentState, event){
+  currentState.teams[event.teamName].mentionCount = event.mentionCount;
+  return currentState;
+};
 
 appState.setConnectionState = function(connectionState){
   d.push("setConnectionState", connectionState);
@@ -42,16 +54,34 @@ appState.selectTeam = function(teamName){
   d.push("selectTeam", teamName);
 };
 
+appState.setUnreadCount = function(teamName, unreadCount){
+  d.push("setUnreadCount", {
+    teamName:teamName,
+    unreadCount:unreadCount
+  });
+};
+
+appState.setMentionCount = function(teamName, mentionCount){
+  d.push("setMentionCount", {
+    teamName:teamName,
+    mentionCount:mentionCount
+  });
+};
+
 appState.initStream = function(){
   var setConnectionStateStream = d.stream("setConnectionState");
   var addTeamStream = d.stream("addTeam");
   var selectTeamStream = d.stream("selectTeam");
+  var setUnreadCountStream = d.stream("setUnreadCount");
+  var setMentionCountStream = d.stream("setMentionCount");
 
   var fullStream = Bacon.update(
     appState.initialState,
     [setConnectionStateStream], onSetConnectionState,
     [addTeamStream], onAddTeam,
-    [selectTeamStream], onSelectTeam
+    [selectTeamStream], onSelectTeam,
+    [setUnreadCountStream], onSetUnreadCount,
+    [setMentionCountStream], onSetMentionCount
   );
   return fullStream;
 };

--- a/src/browser/mattermost-events.js
+++ b/src/browser/mattermost-events.js
@@ -1,0 +1,19 @@
+var notifications = require("./notifications.js").instance;
+var mattermostEvents = {};
+
+mattermostEvents.process_unread = function(event){
+  var unreadCount = parseInt(event.args[0], 10) || 0;
+  notifications.setUnreadCount(event.teamName, unreadCount);
+};
+
+mattermostEvents.process_mention = function(event){
+  var mentionCount = parseInt(event.args[0], 10) || 0;
+  notifications.setMentionCount(event.teamName, mentionCount);
+};
+
+mattermostEvents.process = function(event){
+  var methodName = "process_" + event.channel;
+  mattermostEvents[methodName](event);
+};
+
+module.exports = mattermostEvents;

--- a/src/browser/mattermost-observer.js
+++ b/src/browser/mattermost-observer.js
@@ -1,22 +1,5 @@
 var ipc = require('electron').ipcRenderer;
 
-var notifyHost = function() {
-  var mentionCount = getTotalMentionCount();
-  var unreadCount = $('.unread-title').length;
-
-  ipc.sendToHost('mention-count', mentionCount);
-  ipc.sendToHost('unread-count', unreadCount);
-};
-
-var getTotalMentionCount = function(){
-  var mentionCount = 0;
-  $('.unread-title.has-badge .badge').each(function() {
-    var badgeText = $(this).text();
-    mentionCount += parseInt(badgeText, 10);
-  });
-  return mentionCount;
-};
-
 document.addEventListener("DOMContentLoaded", function() {
   // observe the DOM for mutations, specifically the .ps-container
   // which contains all the sidebar channels
@@ -37,3 +20,24 @@ document.addEventListener("DOMContentLoaded", function() {
     });
   }
 });
+
+var notifyHost = function() {
+  var mentionCount = getTotalMentionCount();
+  var unreadCount = getUnreadCount();
+
+  ipc.sendToHost('mention', mentionCount);
+  ipc.sendToHost('unread', unreadCount);
+};
+
+var getUnreadCount = function(){
+  return $('.unread-title').length;
+};
+
+var getTotalMentionCount = function(){
+  var mentionCount = 0;
+  $('.unread-title.has-badge .badge').each(function() {
+    var badgeText = $(this).text();
+    mentionCount += parseInt(badgeText, 10);
+  });
+  return mentionCount;
+};

--- a/src/browser/notifications.js
+++ b/src/browser/notifications.js
@@ -1,24 +1,17 @@
+var appState = require("./app-state.js");
 var osBadge = require("./os-badge.js");
 var osNotify = require("./os-notify.js");
 
-var Notifications = function(){
-  this.unreadCount = 0;
-  this.mentionCount = 0;
+var Notifications = function(){};
+
+Notifications.prototype.setUnreadCount = function(teamName, unreadCount){
+  osBadge.update(unreadCount);
+  appState.setUnreadCount(teamName, unreadCount);
 };
 
-Notifications.prototype.setUnreadCount = function(unreadCount){
-  this.unreadCount = unreadCount;
-  this.update();
-};
-
-Notifications.prototype.setMentionCount = function(mentionCount){
-  this.mentionCount = mentionCount;
-  this.update();
-};
-
-Notifications.prototype.update = function(){
-  osBadge.update(this.unreadCount);
-  osNotify.update(this.mentionCount);
+Notifications.prototype.setMentionCount = function(teamName, mentionCount){
+  osNotify.update(mentionCount);
+  appState.setMentionCount(teamName, mentionCount);
 };
 
 Notifications.instance = new Notifications();

--- a/src/browser/team-button.jsx
+++ b/src/browser/team-button.jsx
@@ -7,6 +7,8 @@ var TeamButton = React.createClass({
     var iconText = team.name.substr(0,1);
     var isSelected = (team.name === this.props.selectedTeam);
     var selectedClass = isSelected ? "selected" : "not-selected";
+    var unreadCount = this.processCount(team.unreadCount);
+    var mentionCount = this.processCount(team.mentionCount);
     return (
       <div
         className={`teamButton ${selectedClass}`}
@@ -14,13 +16,20 @@ var TeamButton = React.createClass({
       >
         <div className="selectionTab"></div>
         <div className="icon">{iconText}</div>
-        <div className="badge unreadCount">{team.unreadCount}</div>
-        <div className="badge mentionCount">{team.mentionCount}</div>
+        <div className="badge unreadCount">{unreadCount}</div>
+        <div className="badge mentionCount">{mentionCount}</div>
       </div>
     );
   },
   onClick: function(event){
     appState.selectTeam(this.props.team.name);
+  },
+  processCount: function(count){
+    if (count < 100){
+      return count;
+    } else {
+      return "*";
+    }
   }
 });
 

--- a/src/browser/team-button.jsx
+++ b/src/browser/team-button.jsx
@@ -1,0 +1,27 @@
+var appState = require("./app-state.js");
+var React = require("react");
+
+var TeamButton = React.createClass({
+  render: function(){
+    var team = this.props.team;
+    var iconText = team.name.substr(0,1);
+    var isSelected = (team.name === this.props.selectedTeam);
+    var selectedClass = isSelected ? "selected" : "not-selected";
+    return (
+      <div
+        className={`teamButton ${selectedClass}`}
+        onClick={this.onClick}
+      >
+        <div className="selectionTab"></div>
+        <div className="icon">{iconText}</div>
+        <div className="badge unreadCount">{team.unreadCount}</div>
+        <div className="badge mentionCount">{team.mentionCount}</div>
+      </div>
+    );
+  },
+  onClick: function(event){
+    appState.selectTeam(this.props.team.name);
+  }
+});
+
+module.exports = TeamButton;

--- a/src/browser/team-buttons.jsx
+++ b/src/browser/team-buttons.jsx
@@ -1,5 +1,5 @@
-var appState = require("./app-state.js");
 var React = require("react");
+var TeamButton = require("./team-button.jsx");
 require("./team-buttons.less");
 
 var TeamButtons = React.createClass({
@@ -15,22 +15,10 @@ var TeamButtons = React.createClass({
     return names.map(this.renderButton);
   },
   renderButton: function(teamName){
-    var iconText = teamName.substr(0,1);
-    var isSelected = (teamName === this.props.selectedTeam);
-    var selectedClass = isSelected ? "selected" : "not-selected";
+    var team = this.props.teams[teamName];
     return (
-      <div
-        className={`teamButton ${selectedClass}`}
-        key={teamName}
-        onClick={this.onClick}
-        data-teamname={teamName}>
-        {iconText}
-      </div>
+      <TeamButton team={team} key={teamName} selectedTeam={this.props.selectedTeam}/>
     );
-  },
-  onClick: function(event){
-    var teamName = event.target.dataset.teamname;
-    appState.selectTeam(teamName);
   }
 });
 

--- a/src/browser/team-buttons.less
+++ b/src/browser/team-buttons.less
@@ -6,6 +6,7 @@
 
   .teamButton {
     display: flex;
+    position: relative;
     background-color: white;
     border-radius: 5px;
     width: 2em;
@@ -16,13 +17,51 @@
     font-family: sans-serif;
     flex-grow: 1;
     cursor: pointer;
+    box-sizing: content-box;
 
-    &.selected {
-      border: 4px solid #7DBE00;
+    .selectionTab {
+      position: absolute;
+      background-color: white;
+      height: 100%;
+      width: 20px;
+      border-radius: 5px;
+      left: -30px;
     }
 
-    &.not-selected {
-      border: none;
+    &.selected .selectionTab {
+      display: block;
+    }
+
+    &.not-selected .selectionTab {
+      display: none;
+    }
+
+    @badgeSize: 16px;
+    @badgeOffset: -4px;
+
+    .badge {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+      width: @badgeSize;
+      height: @badgeSize;
+      border: 1px solid white;
+      border-radius: .5em;
+      color: white;
+      font-size: 12px;
+    }
+
+    .badge.unreadCount {
+      top: @badgeOffset;
+      right: @badgeOffset;
+      background-color: #B14632;
+    }
+
+    .badge.mentionCount {
+      bottom: @badgeOffset;
+      right: @badgeOffset;
+      background-color: #7DBE00;
     }
   }
 }

--- a/src/browser/team-buttons.less
+++ b/src/browser/team-buttons.less
@@ -36,7 +36,7 @@
       display: none;
     }
 
-    @badgeSize: 16px;
+    @badgeSize: 18px;
     @badgeOffset: -4px;
 
     .badge {
@@ -47,9 +47,9 @@
       width: @badgeSize;
       height: @badgeSize;
       border: 1px solid white;
-      border-radius: .5em;
+      border-radius: 9px;
       color: white;
-      font-size: 12px;
+      font-size: 11px;
     }
 
     .badge.unreadCount {

--- a/src/browser/team-views.jsx
+++ b/src/browser/team-views.jsx
@@ -17,10 +17,10 @@ var TeamViews = React.createClass({
   renderView: function(teamName){
     var team = this.props.teams[teamName];
     var isSelected = (teamName == this.props.selectedTeam);
-    console.log(team.url);
     return (
       <TeamWebview
         teamUrl={team.url}
+        teamName={team.name}
         key={team.name}
         isSelected={isSelected}
         connectionState={this.props.connectionState}

--- a/src/browser/team-webview.jsx
+++ b/src/browser/team-webview.jsx
@@ -1,5 +1,5 @@
 var appState = require("./app-state.js");
-var notifications = require("./notifications.js").instance;
+var mattermostEvents = require("./mattermost-events.js");
 var Overlay = require("./overlay.jsx");
 var React = require("react");
 var ReactDOM = require("react-dom");
@@ -51,16 +51,8 @@ var TeamWebview = React.createClass({
     console.info('Mattermost: ', event.message);
   },
   onIPCMessage: function(event){
-    if (this.props.notifications){
-      if (event.channel === "unread-count"){
-        var unreadCount = parseInt(event.args[0], 10);
-        notifications.setUnreadCount(unreadCount);
-      }
-      else if (event.channel === "mention-count"){
-        var mentionCount = parseInt(event.args[0], 10);
-        notifications.setMentionCount(mentionCount);
-      }
-    }
+    event.teamName = this.props.teamName;
+    mattermostEvents.process(event);
   },
   onWindowFocus: function(){
     if (this.props.isSelected){


### PR DESCRIPTION
Adds little badges to each team for unreads and mentions, and provides a better "selected" icon.

A few things that don't work, yet, and are going to be difficult to get working:

- Notifications for channels that are open, but webviews that are unfocused
- Themes. We could try to guess light/dark from inside the webview and provide two themes for that, but custom themes are probably out, unless Mattermost has an API to fetch colors
