### PR TITLE
add default empty chrome args

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -24,7 +24,8 @@ var defaults = {
   window: {
     width: 1024,
     height: 600
-  }
+  },
+  "chrome-args": {}
 };
 
 settings.load = function(homedir){


### PR DESCRIPTION
This fixes a bug where the user doesn't have a config.json file.