### PR TITLE
Fix pr67

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 env:
   node: true
   browser: true
-
+  es6: true
+  
 ecmaFeatures:
   blockBindings: true
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha",
     "test-watch": "mocha watch"
   },
-  "electronVersion": "0.35.4",
+  "electronVersion": "0.36.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/lloeki/matterfront"
@@ -43,7 +43,7 @@
     "chokidar": "^1.4.1",
     "css-loader": "~0.23.0",
     "electron-connect": "~0.3.3",
-    "electron-prebuilt": "^0.35.4",
+    "electron-prebuilt": ">=0.36.2",
     "eslint": "~1.10.2",
     "ghooks": "~1.0.1",
     "less": "~2.5.3",
@@ -53,14 +53,15 @@
     "razz": "~1.1.1",
     "style-loader": "~0.13.0",
     "watch": "~0.16.0",
-    "webpack": "~1.12.9",
+    "webpack": "^1.12.9",
+    "webpack-target-electron-renderer": "^0.3.0",
     "zepto-node": "~1.0.0"
   },
   "dependencies": {
     "bacon-dispatcher": "~0.9.9",
     "baconjs": "~0.7.82",
     "electron-packager": "^5.1.1",
-    "mkdirp": "~0.5.1",
+    "mkdirp": "^0.5.1",
     "nconf": "~0.8.2",
     "path-extra": "~3.0.0",
     "react": "~0.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterfront",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Mattermost frontend app powered by electron",
   "homepage": "https://github.com/lloeki/matterfront",
   "author": "Brian Vanderbusch <brian@hackerhappyhour.com> (https://github.com/H3Chief)",
@@ -40,6 +40,7 @@
     "babel-register": "~6.3.13",
     "chai": "~3.4.1",
     "chai-jq": "0.0.9",
+    "chokidar": "^1.4.1",
     "css-loader": "~0.23.0",
     "electron-connect": "~0.3.3",
     "electron-prebuilt": "^0.35.4",

--- a/src/browser/team-observer.js
+++ b/src/browser/team-observer.js
@@ -1,7 +1,7 @@
 var appState = require("./app-state.js");
 //ipc is deprecated, but we can't switch to `require("electron")` until
 //the webpack target is updated to side-step `electron`. :frowning:
-var ipcRenderer = require('ipc');
+var ipcRenderer = require('electron').ipcRenderer;
 
 var teamObserver = {};
 

--- a/src/browser/team-observer.js
+++ b/src/browser/team-observer.js
@@ -1,6 +1,4 @@
 var appState = require("./app-state.js");
-//ipc is deprecated, but we can't switch to `require("electron")` until
-//the webpack target is updated to side-step `electron`. :frowning:
 var ipcRenderer = require('electron').ipcRenderer;
 
 var teamObserver = {};

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-var app = require('app');
-var BrowserWindow = require('browser-window');
+var electron = require('electron');
+var app = electron.app;
+var BrowserWindow = electron.BrowserWindow;
 var chromeArgs = require('./chrome-args.js');
 var menu = require('./menu.js');
-var path = require('path');
 var settings = require('./settings.js');
 var teams = require("./teams.js");
 
@@ -26,7 +26,7 @@ app.on('ready', function() {
   var quitting = false;
   mainWindow = new BrowserWindow(settings.get('window'));
 
-  var indexPath = path.join('file://', __dirname, 'browser/index.html');
+  var indexPath = `file://${__dirname}/browser/index.html`;
   mainWindow.loadURL(indexPath);
 
   app.on('activate', function(e, hasVisibleWindows) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
+var webpackTargetElectronRenderer = require('webpack-target-electron-renderer');
 
-module.exports = {
-  target: "electron",
+var options = {
   entry: ['./src/browser/index.js'],
   output: {
     path: './browser-build',
@@ -21,3 +21,7 @@ module.exports = {
     }]
   }
 }
+
+options.target = webpackTargetElectronRenderer(options);
+
+module.exports = options;


### PR DESCRIPTION
This Merge handles a few issues:

- missing deps in `package.json`
 - chokidar (devDependency)
 - mkdirp (dependency)
- updated electron to `0.36.2`
 - refactor usage of modules to new `require('electron')`, no longer uses `require('app'), `require('ipc')`, or `require('BrowserWindow')`
 - changes needed to webpack to support the new build targeting for electron (added devDep: `webpack-target-electron-renderer`
- electron now uses node v5.1+, so I added es6 support to the `.eslintrc`
